### PR TITLE
Prevent invalid host header

### DIFF
--- a/roles/nginx/templates/youtubeadl.j2
+++ b/roles/nginx/templates/youtubeadl.j2
@@ -7,6 +7,13 @@ upstream {{ application_name }}_wsgi_server {
 }
 
 server {
+    listen        80 default_server;
+    server_name   _;
+    server_tokens off;
+    return        444;
+}
+
+server {
     listen      80;
     server_name {{ nginx_server_name }};
     rewrite     ^ https://$server_name$request_uri? permanent;


### PR DESCRIPTION
Invalid host headers will reach the Django application, throwing an error, cluttering logs, posing possible security risks without rejection at the Nginx level.

This also appears to prevent 400s returned by Nginx when the host header is blank from leaking the Nginx version and OS.

See: https://nginx.org/en/docs/http/request_processing.html#how_to_prevent_undefined_server_names